### PR TITLE
porting to clang 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tunneltanks
 *.bmp
 /SDL/docs/
 /Build/
+/build/
 /obj/
 *.vcxproj.user
 **/.vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,13 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.13)
 
 ################################################################################
 ### COMPILING THE PROJECT: #####################################################
 ################################################################################
 
-project(tunneltanks C)
+project(tunneltanks VERSION 2.0)
 
-set(SDL_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/sdl2/include")
+find_package(SDL2 REQUIRED)
+find_package(Boost REQUIRED)
 
 # Support both 32 and 64 bit builds
 if (${CMAKE_SIZEOF_VOID_P} MATCHES 8)
@@ -15,19 +16,20 @@ else ()
   set(SDL_LIBRARY "${CMAKE_CURRENT_LIST_DIR}/sdl2/lib/x86/SDL2.lib;${CMAKE_CURRENT_LIST_DIR}/lib/x86/SDL2main.lib")
 endif ()
 
-string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
-
-# Verify that SDL is installed:
-include_directories( ${SDL_INCLUDE_DIR} )
-include_directories( "src/include" )
-
 # Set up the compiler, and find all source files:
-set(CMAKE_C_FLAGS "-g -ansi -Wall -O3 -DUSE_SDL_GAMELIB")
-file(GLOB source_files "src/*.c" "src/gamelib/SDL/*.c")
+file(GLOB source_files "src/*.c" "src/*.cpp" "src/include/*.cpp" "src/gamelib/SDL/*.c" "src/gamelib/SDL/*.cpp")
 
 # Link and compile:
-link_libraries( ${SDL_LIBRARY} )
 add_executable( tunneltanks ${source_files} )
+
+if (NOT WINDOWS)
+	target_compile_options(tunneltanks PUBLIC "-Wall")
+endif()
+
+target_compile_definitions(tunneltanks PUBLIC "USE_SDL_GAMELIB" "DEBUG_TRACE_LEVEL=3")
+target_compile_features(tunneltanks PUBLIC cxx_std_20)
+target_link_libraries(tunneltanks PUBLIC ${SDL2_LIBRARIES} Boost::boost)
+target_include_directories(tunneltanks PUBLIC ${SDL2_INCLUDE_DIRS} "src/include" "src" "src/gamelib" "src/gamelib/SDL")
 
 # Enable the make install:
 install(

--- a/src/color_palette.cpp
+++ b/src/color_palette.cpp
@@ -82,13 +82,13 @@ Color ColorPalette::Get(Colors colorName)
 Color ColorPalette::GetPrimary(TankColor index)
 {
     assert(index >= 0 && index < PrimaryColors);
-    return Primaries[index];
+    return Primaries[static_cast<int>(index)];
 }
 
 Color * ColorPalette::GetTank(TankColor index)
 {
     assert(index >= 0 && index < PrimaryColors);
-    return Tanks[index];
+    return Tanks[static_cast<int>(index)];
 }
 
 void ColorPalette::Set(Colors colorName, Color color) { Values[static_cast<int>(colorName)] = color; }
@@ -96,13 +96,13 @@ void ColorPalette::Set(Colors colorName, Color color) { Values[static_cast<int>(
 void ColorPalette::SetPrimary(TankColor index, Color color)
 {
     assert(index >= 0 && index < PrimaryColors);
-    Primaries[index] = color;
+    Primaries[static_cast<int>(index)] = color;
 }
 
 void ColorPalette::SetTank(TankColor index, Color color_1, Color color_2, Color color_3)
 {
     assert(index >= 0 && index < PrimaryColors);
-    Tanks[index][0] = color_1;
-    Tanks[index][1] = color_2;
-    Tanks[index][2] = color_3;
+    Tanks[static_cast<int>(index)][0] = color_1;
+    Tanks[static_cast<int>(index)][1] = color_2;
+    Tanks[static_cast<int>(index)][2] = color_3;
 }

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -1,11 +1,11 @@
 #pragma once
 #include <cstdint>
-#include <exception>
+#include <stdexcept>
 
-class GameException : public std::exception
+class GameException : public std::runtime_error
 {
   public:
-    GameException(const char * message) : std::exception(message) {}
+    GameException(const char * message) : std::runtime_error(message) {}
 };
 
 class GameInitException : public GameException

--- a/src/font_renderer.h
+++ b/src/font_renderer.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 #include <array>
-
+#include <string_view>
 #include "bitmaps.h"
 
 class GameSystem;

--- a/src/gamelib/SDL/logging.cpp
+++ b/src/gamelib/SDL/logging.cpp
@@ -1,7 +1,9 @@
 #include <cstdio>
 #include <cstdarg>
 #include "require_sdl.h"
+#ifdef _WIN32
 #include <debugapi.h>
+#endif
 
 void     gamelib_print (const char *str, ...) {
 	va_list l;
@@ -13,8 +15,11 @@ void     gamelib_print (const char *str, ...) {
 void     gamelib_debug (const char *str, ...) {
 	va_list l;
 	va_start(l, str);
-	//vfprintf(stderr, str, l) ;
+	#ifdef _WIN32
 	OutputDebugString(str);
+	#else
+	vfprintf(stderr, str, l) ;
+	#endif
 	va_end(l);
 }
 

--- a/src/gamelib/SDL/sdl_controller.cpp
+++ b/src/gamelib/SDL/sdl_controller.cpp
@@ -1,7 +1,7 @@
 #include <SDL.h>
 #include <cstdlib>
 
-#include <sdl_controller.h>
+#include "sdl_controller.h"
 #include <gamelib.h>
 #include <tank.h>
 

--- a/src/include/bitmaps.h
+++ b/src/include/bitmaps.h
@@ -31,7 +31,7 @@ class ImageData
 
   public:
     /* In-place value initialization from hardcoded byte-array */
-    ImageData(Size size, std::initializer_list<DataType> data) : data(data), size(size)
+    ImageData(Size size, std::initializer_list<DataType> data) : size(size), data(data)
     {
         assert(size.x * size.y == int(data.size()));
     }

--- a/src/include/color.h
+++ b/src/include/color.h
@@ -4,10 +4,11 @@
 struct ColorLayout
 {
     /* The order is actually important - if it's identical to memory layout of our render surface, it's just a memcopy*/
+    /* and it will be UB, if you do memcopy :) */
     uint8_t b{}, g{}, r{}, a{};
 
     ColorLayout() = default;
-    ColorLayout(unsigned char r, unsigned char g, unsigned char b, unsigned char a = 255) : r(r), g(g), b(b), a(a) {}
+    ColorLayout(unsigned char r, unsigned char g, unsigned char b, unsigned char a = 255) : b(b), g(g), r(r), a(a) {}
 };
 
 struct Color : public ColorLayout

--- a/src/include/containers_queue.h
+++ b/src/include/containers_queue.h
@@ -40,12 +40,12 @@ template <typename Value> class counted_lockfree_queue : private boost::lockfree
     counted_lockfree_queue(int capacity) : parent(capacity) {}
     bool pop(Value & val)
     {
-        count.fetch_sub(1, std::memory_order::memory_order_relaxed);
+        count.fetch_sub(1, std::memory_order_relaxed);
         return parent::pop(val);
     }
     bool push(const Value & val)
     {
-        count.fetch_add(1, std::memory_order::memory_order_relaxed);
+        count.fetch_add(1, std::memory_order_relaxed);
         return parent::push(val);
     }
     size_t size() { return count; }

--- a/src/include/gui_widgets.h
+++ b/src/include/gui_widgets.h
@@ -116,7 +116,7 @@ class Crosshair : public BitmapRender
 class ResourcesMinedDisplay : public GuiWidget
 {
     Tank * tank;
-    HorizontalAlign alignment;
+    [[maybe_unused]] HorizontalAlign alignment;
   public:
     ResourcesMinedDisplay(ScreenRect screen_rect, HorizontalAlign alignment, Tank * tank) : GuiWidget(screen_rect), tank(tank), alignment(alignment) {}
     void Draw(Screen * screen) override;

--- a/src/include/level.h
+++ b/src/include/level.h
@@ -152,12 +152,12 @@ void Level::ForEachVoxelParallel(VoxelFunc voxelFunc, WorkerCount worker_count)
 template <typename CountFunc>
 int Level::CountNeighborValues(Position pos, CountFunc count_func)
 {
-    return count_func(GetVoxelRaw({pos.x - 1 + GetSize().x * (pos.y - 1)})) +
-           count_func(GetVoxelRaw({pos.x + GetSize().x * (pos.y - 1)})) +
-           count_func(GetVoxelRaw({pos.x + 1 + GetSize().x * (pos.y - 1)})) +
-           count_func(GetVoxelRaw({pos.x - 1 + GetSize().x * (pos.y)})) +
-           count_func(GetVoxelRaw({pos.x + 1 + GetSize().x * (pos.y)})) +
-           count_func(GetVoxelRaw({pos.x - 1 + GetSize().x * (pos.y + 1)})) +
-           count_func(GetVoxelRaw({pos.x + GetSize().x * (pos.y + 1)})) +
-           count_func(GetVoxelRaw({pos.x + 1 + GetSize().x * (pos.y + 1)}));
+    return count_func(GetVoxelRaw((pos.x - 1 + GetSize().x * (pos.y - 1)))) +
+           count_func(GetVoxelRaw((pos.x + GetSize().x * (pos.y - 1)))) +
+           count_func(GetVoxelRaw((pos.x + 1 + GetSize().x * (pos.y - 1)))) +
+           count_func(GetVoxelRaw((pos.x - 1 + GetSize().x * (pos.y)))) +
+           count_func(GetVoxelRaw((pos.x + 1 + GetSize().x * (pos.y)))) +
+           count_func(GetVoxelRaw((pos.x - 1 + GetSize().x * (pos.y + 1)))) +
+           count_func(GetVoxelRaw((pos.x + GetSize().x * (pos.y + 1)))) +
+           count_func(GetVoxelRaw((pos.x + 1 + GetSize().x * (pos.y + 1))));
 }

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -65,14 +65,14 @@ void Level::SetVoxelRaw(int offset, LevelPixel voxel)
 
 int Level::CountNeighbors(Position pos, LevelPixel value)
 {
-    return !!(value == GetVoxelRaw({pos.x - 1 + GetSize().x * (pos.y - 1)})) +
-           !!(value == GetVoxelRaw({pos.x + GetSize().x * (pos.y - 1)})) +
-           !!(value == GetVoxelRaw({pos.x + 1 + GetSize().x * (pos.y - 1)})) +
-           !!(value == GetVoxelRaw({pos.x - 1 + GetSize().x * (pos.y)})) +
-           !!(value == GetVoxelRaw({pos.x + 1 + GetSize().x * (pos.y)})) +
-           !!(value == GetVoxelRaw({pos.x - 1 + GetSize().x * (pos.y + 1)})) +
-           !!(value == GetVoxelRaw({pos.x + GetSize().x * (pos.y + 1)})) +
-           !!(value == GetVoxelRaw({pos.x + 1 + GetSize().x * (pos.y + 1)}));
+    return !!(value == GetVoxelRaw((pos.x - 1 + GetSize().x * (pos.y - 1)))) +
+           !!(value == GetVoxelRaw((pos.x + GetSize().x * (pos.y - 1)))) +
+           !!(value == GetVoxelRaw((pos.x + 1 + GetSize().x * (pos.y - 1)))) +
+           !!(value == GetVoxelRaw((pos.x - 1 + GetSize().x * (pos.y)))) +
+           !!(value == GetVoxelRaw((pos.x + 1 + GetSize().x * (pos.y)))) +
+           !!(value == GetVoxelRaw((pos.x - 1 + GetSize().x * (pos.y + 1)))) +
+           !!(value == GetVoxelRaw((pos.x + GetSize().x * (pos.y + 1)))) +
+           !!(value == GetVoxelRaw((pos.x + 1 + GetSize().x * (pos.y + 1))));
 }
 
 void Level::MaterializeLevelTerrainAndBases()
@@ -282,7 +282,7 @@ void Level::DumpBitmap(const char * filename) const
             color_data[i] = static_cast<Color>(GetVoxelColor(this->GetVoxelRaw(i)));
 
         {
-            auto trace = MeasureFunction<5>("DumpBitmap");
+            [[maybe_unused]] auto trace = MeasureFunction<5>("DumpBitmap");
             BmpFile::SaveToFile(color_data, filename);
         }
     }

--- a/src/levelgen.cpp
+++ b/src/levelgen.cpp
@@ -133,14 +133,14 @@ void LevelGenerator::PrintAllGenerators(FILE * out)
 
 int Queries::CountNeighborValues(Position pos, Level * level)
 {
-    return (char)level->GetVoxelRaw({pos.x - 1 + level->GetSize().x * (pos.y - 1)}) +
-           (char)level->GetVoxelRaw({pos.x + level->GetSize().x * (pos.y - 1)}) +
-           (char)level->GetVoxelRaw({pos.x + 1 + level->GetSize().x * (pos.y - 1)}) +
-           (char)level->GetVoxelRaw({pos.x - 1 + level->GetSize().x * (pos.y)}) +
-           (char)level->GetVoxelRaw({pos.x + 1 + level->GetSize().x * (pos.y)}) +
-           (char)level->GetVoxelRaw({pos.x - 1 + level->GetSize().x * (pos.y + 1)}) +
-           (char)level->GetVoxelRaw({pos.x + level->GetSize().x * (pos.y + 1)}) +
-           (char)level->GetVoxelRaw({pos.x + 1 + level->GetSize().x * (pos.y + 1)});
+    return (char)level->GetVoxelRaw((pos.x - 1 + level->GetSize().x * (pos.y - 1))) +
+           (char)level->GetVoxelRaw((pos.x + level->GetSize().x * (pos.y - 1))) +
+           (char)level->GetVoxelRaw((pos.x + 1 + level->GetSize().x * (pos.y - 1))) +
+           (char)level->GetVoxelRaw((pos.x - 1 + level->GetSize().x * (pos.y))) +
+           (char)level->GetVoxelRaw((pos.x + 1 + level->GetSize().x * (pos.y))) +
+           (char)level->GetVoxelRaw((pos.x - 1 + level->GetSize().x * (pos.y + 1))) +
+           (char)level->GetVoxelRaw((pos.x + level->GetSize().x * (pos.y + 1))) +
+           (char)level->GetVoxelRaw((pos.x + 1 + level->GetSize().x * (pos.y + 1)));
 }
 
 } // namespace levelgen

--- a/src/levelgen_braid.cpp
+++ b/src/levelgen_braid.cpp
@@ -294,7 +294,7 @@ std::unique_ptr<Level> BraidLevelGenerator::Generate(Size size)
 	
 	braid_free(b);
 
-    return std::move(lvl);
+    return lvl;
 }
 
 }

--- a/src/levelgen_maze.cpp
+++ b/src/levelgen_maze.cpp
@@ -211,7 +211,7 @@ std::unique_ptr<Level> MazeLevelGenerator::Generate(Size size)
 	}
 	
 	maze_free(m);
-    return std::move(level);
+    return level;
 }
 
 }

--- a/src/levelgen_simple.cpp
+++ b/src/levelgen_simple.cpp
@@ -169,7 +169,7 @@ std::unique_ptr<Level> SimpleLevelGenerator::Generate(Size size)
 
     /* Add a few spawns, and we're good to go! */
     add_spawns(lvl);
-    return std::move(level);
+    return level;
 }
 
 } // namespace levelgen::simple

--- a/src/levelgen_toast.cpp
+++ b/src/levelgen_toast.cpp
@@ -142,14 +142,14 @@ static void generate_tree(Level *lvl) {
 //
 // Much less instructions. Optimizer cannot see it through and fold it :(
 static int has_neighbor(Level* lvl, int x, int y) {
-	if (lvl->GetVoxelRaw({ x - 1 + lvl->GetSize().x * (y - 1) }) == LevelPixel::LevelGenDirt) return 1;
-	if (lvl->GetVoxelRaw({ x     + lvl->GetSize().x * (y - 1) }) == LevelPixel::LevelGenDirt) return 1;
-	if (lvl->GetVoxelRaw({ x + 1 + lvl->GetSize().x * (y - 1) }) == LevelPixel::LevelGenDirt) return 1;
-	if (lvl->GetVoxelRaw({ x - 1 + lvl->GetSize().x * (y    ) }) == LevelPixel::LevelGenDirt) return 1;
-	if (lvl->GetVoxelRaw({ x + 1 + lvl->GetSize().x * (y    ) }) == LevelPixel::LevelGenDirt) return 1;
-	if (lvl->GetVoxelRaw({ x - 1 + lvl->GetSize().x * (y + 1) }) == LevelPixel::LevelGenDirt) return 1;
-	if (lvl->GetVoxelRaw({ x     + lvl->GetSize().x * (y + 1) }) == LevelPixel::LevelGenDirt) return 1;
-	if (lvl->GetVoxelRaw({ x + 1 + lvl->GetSize().x * (y + 1) }) == LevelPixel::LevelGenDirt) return 1;
+	if (lvl->GetVoxelRaw(( x - 1 + lvl->GetSize().x * (y - 1) )) == LevelPixel::LevelGenDirt) return 1;
+	if (lvl->GetVoxelRaw(( x     + lvl->GetSize().x * (y - 1) )) == LevelPixel::LevelGenDirt) return 1;
+	if (lvl->GetVoxelRaw(( x + 1 + lvl->GetSize().x * (y - 1) )) == LevelPixel::LevelGenDirt) return 1;
+	if (lvl->GetVoxelRaw(( x - 1 + lvl->GetSize().x * (y    ) )) == LevelPixel::LevelGenDirt) return 1;
+	if (lvl->GetVoxelRaw(( x + 1 + lvl->GetSize().x * (y    ) )) == LevelPixel::LevelGenDirt) return 1;
+	if (lvl->GetVoxelRaw(( x - 1 + lvl->GetSize().x * (y + 1) )) == LevelPixel::LevelGenDirt) return 1;
+	if (lvl->GetVoxelRaw(( x     + lvl->GetSize().x * (y + 1) )) == LevelPixel::LevelGenDirt) return 1;
+	if (lvl->GetVoxelRaw(( x + 1 + lvl->GetSize().x * (y + 1) )) == LevelPixel::LevelGenDirt) return 1;
 	return 0;
 }
 
@@ -464,7 +464,7 @@ std::unique_ptr<Level> ToastLevelGenerator::Generate(Size size)
 	randomly_expand(lvl);
 	smooth_cavern(lvl);
 
-	return std::move(level);
+	return level;
 }
 
 #ifdef _TESTING

--- a/src/link.h
+++ b/src/link.h
@@ -171,7 +171,7 @@ class Link : public Invalidable
 /* LinkMap: Manages all link point updates and links */
 class LinkMap
 {
-    Level * level;
+    [[maybe_unused]] Level * level;
     ValueContainer<LinkPoint> link_points = {};
     ValueContainer<Link> links = {};
 

--- a/src/machine.h
+++ b/src/machine.h
@@ -41,7 +41,7 @@ enum class HarvesterType
 class Harvester final : public Machine
 {
     using Base = Machine;
-    HarvesterType type;
+    [[maybe_unused]] HarvesterType type;
 
     RepetitiveTimer harvest_timer{tweak::rules::HarvestTimer};
   public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include "base.h"
 #include <control.h>
+#ifdef _WIN32
 #include <crtdbg.h>
+#endif
 #include <cstdlib>
 #include <cstring>
 #include <game.h>
@@ -29,7 +31,9 @@ int main(int argc, char * argv[])
 {
     try
     {
+        #ifdef _WIN32
         _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+        #endif
 
         return GameMain(argc, argv);
     }
@@ -202,8 +206,7 @@ int GameMain(int argc, char * argv[])
         ::global_game = std::make_unique<Game>(config);
         /* Play the game: */
         ::global_game->BeginGame();
-        int frames_to_do = 1500;
-        gamelib_main_loop([&frames_to_do]() -> bool { return global_game->AdvanceStep(); });
+        gamelib_main_loop([]() -> bool { return global_game->AdvanceStep(); });
 
         /* Release global resources earlier than atexit global teardown*/
         ::global_game->ClearWorld();

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -15,7 +15,7 @@
 
 void Bullet::Advance(TankList * tankList)
 {
-    auto IteratePositions = [this, tankList](PositionF tested_pos, PositionF prev_pos) {
+    auto IteratePositions = [this](PositionF tested_pos, PositionF prev_pos) {
         this->pos = tested_pos;
         this->pos_blur_from = prev_pos;
 
@@ -27,12 +27,13 @@ void Bullet::Advance(TankList * tankList)
                 tank.GetReactor().Exhaust(tweak::tank::ShotDamage);
                 return true;
         },
-        [this](auto & machine)
+        [](auto & machine)
         {
             machine.GetReactor().Exhaust(tweak::tank::ShotDamage);
             return true;
         },
-        [this](LevelPixel level_pixel) { return Pixel::IsAnyCollision(level_pixel); }))
+        [](LevelPixel level_pixel) { return Pixel::IsAnyCollision(level_pixel); }))
+
         {
             for (Shrapnel & shrapnel : ExplosionDesc::AllDirections(
                                            this->pos_blur_from.ToIntPosition(), tweak::explosion::normal::ShrapnelCount,
@@ -70,10 +71,8 @@ void FlyingBarrel::Advance(TankList * tankList, ExplosionFuncType explosionFunc)
     auto prev_positions = boost::circular_buffer<PositionF>{this->explode_distance + 1ull};
     int search_step = 0;
     const int search_step_count = this->explode_distance + int(std::round(this->speed.GetSize()));
-    
-    PositionF advanced_pos = {};
 
-    auto IteratePositions = [this, &search_step, &prev_positions, tankList](PositionF tested_pos, PositionF prev_pos) {
+    auto IteratePositions = [this, &search_step, &prev_positions](PositionF tested_pos, PositionF prev_pos) {
         prev_positions.push_back(tested_pos);
         ++search_step;
 

--- a/src/resources.h
+++ b/src/resources.h
@@ -64,19 +64,19 @@ struct HealthAmount : public ResourceAmount<HealthAmount>
 /* Beautiful literals. 10_health, 15_dirt, 35_minerals!  */
 constexpr DirtAmount operator"" _dirt(std::uint64_t dirt_value) noexcept
 {
-    return DirtAmount{{static_cast<int>(dirt_value)}};
+    return DirtAmount{static_cast<int>(dirt_value)};
 }
 constexpr MineralsAmount operator"" _minerals(std::uint64_t mineral_value) noexcept
 {
-    return MineralsAmount{{static_cast<int>(mineral_value)}};
+    return MineralsAmount{static_cast<int>(mineral_value)};
 }
 constexpr EnergyAmount operator"" _energy(std::uint64_t energy_value) noexcept
 {
-    return EnergyAmount{{static_cast<int>(energy_value)}};
+    return EnergyAmount{static_cast<int>(energy_value)};
 }
 constexpr HealthAmount operator"" _health(std::uint64_t health_value) noexcept
 {
-    return HealthAmount{{static_cast<int>(health_value)}};
+    return HealthAmount{static_cast<int>(health_value)};
 }
 
 

--- a/src/shape_renderer.cpp
+++ b/src/shape_renderer.cpp
@@ -135,8 +135,8 @@ void ShapeRenderer::DrawRectanglePart(Surface * surface, Rect screen_rect, int s
                                       Color outline_color)
 {
     int pixels_drawn = 0;
-    const int start_draw = std::max(0, skip_pixels);
-    const int stop_draw = start_draw + draw_pixels;
+    //const int start_draw = std::max(0, skip_pixels);
+    //const int stop_draw = start_draw + draw_pixels;
 
     /* Draw outline using 4 lines */
     DrawLinePart(surface, {screen_rect.Left(), screen_rect.Top()}, 

--- a/src/tank_list.cpp
+++ b/src/tank_list.cpp
@@ -3,7 +3,6 @@
 
 #include <level.h>
 #include <projectile.h>
-#include <ranges>
 #include <tank.h>
 #include <tank_list.h>
 #include <tank_sprites.h>

--- a/src/weapon.cpp
+++ b/src/weapon.cpp
@@ -4,6 +4,8 @@
 #include "projectile.h"
 #include "world.h"
 
+#include <cassert>
+
 /*
 void WeaponCannonDescriptor::SpawnProjectile(Position pos, DirectionF direction, Tank * tank)
 {
@@ -46,6 +48,8 @@ Duration Weapon::Fire(Position pos, DirectionF direction, Tank * tank)
         GetWorld()->GetProjectileList()->Add(
             DirtBarrel{pos, direction * tweak::weapon::DirtBarrelSpeed, GetWorld()->GetLevel(), tank});
         return tweak::weapon::ConcreteSprayCooldown;
+    default:
+        assert(false);
     }
     return tweak::weapon::CannonCooldown;
 }


### PR DESCRIPTION
- making CMakeLists.txt useful
- remove lots of warnings
- std::exception doesn't const char * constructor
- missing includes
- TODO: files are randomly spready and counts with include path to all directories
- don't use `return std::move(...)` it blocks RVO
- a lots of unused variables
- IFDEFed windows include
- removed <range> include
- concepts result is not a type but another concept, as there is missing <concepts>  in clang10, I implemented the is_same
- reordering constructor paramters
- std::memory_order_relaxed proper name (as the memory_order enum is not yet implemented in libc++)
- I don't know why there are GetVoxelRaw({expression})