### PR TITLE
Benchmark level creation loop

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -211,7 +211,10 @@ void game_finalize(GameData *gd) {
 	tl  = new TankList(lvl, pl);
 	
 	/* Generate our random level: */
-	generate_level(lvl, gd->data.config.gen);
+	for (int i = 20; i-- > 0; ) {
+		lvl = level_new(b, gd->data.config.w, gd->data.config.h);
+		generate_level(lvl, gd->data.config.gen);
+	}
 	level_decorate(lvl);
 	level_make_bases(lvl);
 	


### PR DESCRIPTION
## Summary
- Benchmark level creation by running generation 20 times in `src/game.c`.
- Keep game logic unchanged while adding a simple performance probe.

## Test plan
- [ ] Build the project.
- [ ] Run the benchmark flow and verify 20 generation iterations complete.
- [ ] Confirm no gameplay behavior regression in a normal run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Repeated `level_new` calls in the loop overwrite `lvl` without freeing earlier levels, which may introduce memory leaks and change initialization cost/behavior during game startup.
> 
> **Overview**
> Adds a simple benchmark/probe in `game_finalize` by running `generate_level` in a 20-iteration loop, re-creating the `Level` each time and using the last generated level for decoration, base placement, and rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 680dccd1756570159ced0914b0511887d92691de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->