### PR TITLE
Adjust headers for compiler-error workaround

### DIFF
--- a/src/include/raycaster.h
+++ b/src/include/raycaster.h
@@ -41,7 +41,7 @@ public:
                 continue;
             }
             /* Check if we went over the edge of one more pixel. Do this only if visit_partial was requested */
-            if ((flags & VisitFlags::PixelsMustTouchSides) && prev.x != next.x && prev.y != next.y &&
+            if ((flags) & (VisitFlags::PixelsMustTouchSides) && prev.x != next.x && prev.y != next.y &&
                 std::abs(one_step.x) != std::abs(one_step.y))
             {
                 /* Detect the touched pixel and visit it as well */

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -257,3 +257,9 @@ class holder_with_deleter : public std::unique_ptr<Type, void (*)(Type *)>
     holder_with_deleter() : base{nullptr, [](Type *) {}} {};
     holder_with_deleter(Type * value, void (*deleter)(Type *)) : base{value, deleter} {}
 };
+
+template <typename TEnum>
+bool HasFlag(TEnum value, TEnum flag)
+{
+    return (static_cast<std::underlying_type_t<TEnum>>(value) & static_cast<std::underlying_type_t<TEnum>>(value)) != 0;
+}


### PR DESCRIPTION
## Summary
- Update header type declarations in `src/include/types.h` and related raycaster include usage.
- Capture a targeted change intended to address an internal compiler error scenario.

## Test plan
- [ ] Build the project with the affected toolchain configuration.
- [ ] Verify the previous internal compiler error no longer occurs.
- [ ] Smoke-test rendering to confirm raycaster/type behavior remains correct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches widely included headers and changes how flag checks may be expressed; the new `HasFlag` helper is easy to misuse if incorrect, potentially causing subtle control-flow bugs if adopted.
> 
> **Overview**
> Adjusts the `Raycaster::Cast` flag-check expression in `raycaster.h` (parenthesized `flags` in the bitwise `&`) as a compiler/workaround-oriented header tweak.
> 
> Updates `types.h` by fixing the missing trailing newline and adding a new generic `HasFlag` enum helper for bitmask checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43a8f4500641ed855eddc0271c5787429744e7da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->